### PR TITLE
fix incorrect next imports using next 9.3.4

### DIFF
--- a/src/parseNextConfig.ts
+++ b/src/parseNextConfig.ts
@@ -1,8 +1,8 @@
 // Based on
 // https://github.com/danielcondemarin/serverless-nextjs-plugin/blob/master/packages/serverless-nextjs-plugin/lib/parseNextConfiguration.js
 // by Daniel Condemarin
-const nextLoadConfig = require("next-server/dist/server/config").default;
-const { PHASE_PRODUCTION_BUILD } = require("next-server/dist/lib/constants");
+const nextLoadConfig = require("next/dist/next-server/server/config").default;
+const { PHASE_PRODUCTION_BUILD } = require("next/constants");
 
 export function parseNextJsConfig(nextConfigDir: string) {
   const nextConfiguration = nextLoadConfig(


### PR DESCRIPTION
references to next module paths were incorrect... updated to match actual paths in next distribution.

error when running with next 9.3.4:

```bash
$ yarn jetzt .
yarn run v1.22.4
$ /Workspace/github/dig/nextjs-azure-function/node_modules/.bin/jetzt .
internal/modules/cjs/loader.js:983
  throw err;
  ^

Error: Cannot find module 'next-server/dist/server/config'
Require stack:
- /Workspace/github/dig/nextjs-azure-function/node_modules/jetzt/lib/parseNextConfig.js
- /Workspace/github/dig/nextjs-azure-function/node_modules/jetzt/lib/build.js
- /Workspace/github/dig/nextjs-azure-function/node_modules/jetzt/lib/run.js
- /Workspace/github/dig/nextjs-azure-function/node_modules/jetzt/lib/index.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:980:15)
    at Function.Module._load (internal/modules/cjs/loader.js:862:27)
    at Module.require (internal/modules/cjs/loader.js:1040:19)
    at require (internal/modules/cjs/helpers.js:72:18)
    at Object.<anonymous> (/Workspace/github/dig/nextjs-azure-function/node_modules/jetzt/lib/parseNextConfig.js:6:22)
    at Module._compile (internal/modules/cjs/loader.js:1151:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1171:10)
    at Module.load (internal/modules/cjs/loader.js:1000:32)
    at Function.Module._load (internal/modules/cjs/loader.js:899:14)
    at Module.require (internal/modules/cjs/loader.js:1040:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/Workspace/github/dig/nextjs-azure-function/node_modules/jetzt/lib/parseNextConfig.js',
    '/Workspace/github/dig/nextjs-azure-function/node_modules/jetzt/lib/build.js',
    '/Workspace/github/dig/nextjs-azure-function/node_modules/jetzt/lib/run.js',
    '/Workspace/github/dig/nextjs-azure-function/node_modules/jetzt/lib/index.js'
  ]
}
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

### package.json

```json
{
  "name": "nextjs-azure-function",
  "version": "1.0.0",
  "main": "index.js",
  "license": "MIT",
  "scripts": {
    "dev": "NODE_OPTIONS='--inspect' next",
    "build": "next build",
    "start": "next start"
  },
  "dependencies": {
    "next": "^9.3.4",
    "react": "^16.13.1",
    "react-dom": "^16.13.1"
  },
  "devDependencies": {
    "@types/node": "^13.11.1",
    "@types/react": "^16.9.34",
    "jetzt": "0.0.7",
    "typescript": "^3.8.3"
  }
}
```